### PR TITLE
Handle parent information when capture transaction

### DIFF
--- a/app/jobs/orders_create_job.rb
+++ b/app/jobs/orders_create_job.rb
@@ -4,10 +4,21 @@ class OrdersCreateJob < ActiveJob::Base
   def perform(shop_domain:, webhook:)
     shop = Shop.find_by(shopify_domain: shop_domain)
     shop.with_shopify_session do
-    	puts webhook['gateway']
-    	if webhook['gateway'] == "Cash on Delivery (COD)" || webhook['gateway'].include?('代金')
-		    ShopifyAPI::Transaction.create({order_id: webhook['id'], kind: 'capture'})
-    	end
+      puts webhook['gateway']
+      return unless webhook['gateway'] == "Cash on Delivery (COD)" || webhook['gateway'].include?('代金')
+
+      order_id = webhook['id']
+      shopify_order_transactions = ShopifyAPI::Transaction.find(:all, params: { order_id: order_id })&.to_a
+      shopify_parent_transaction = (shopify_order_transactions || []).select { |t| t.kind == 'authorization' }.last
+
+      capture_transaction_record = {
+      kind: 'capture',
+      order_id: order_id,
+      parent_id: shopify_parent_transaction&.id,
+      authorization: shopify_parent_transaction&.authorization
+      }
+
+      ShopifyAPI::Transaction.create(capture_transaction_record)
     end
   end
 end


### PR DESCRIPTION
> When creating Transactions to capture an authorization, always include either the ‘authorization’ or ‘parent_id’ parameter to specify which authorization you’d like to capture. In order to capture payments successfully, apps are required to allow for multiple authorization transactions.